### PR TITLE
Use varName variable for correct assignment in variable declaration question

### DIFF
--- a/variable-declaration.js
+++ b/variable-declaration.js
@@ -17,7 +17,7 @@ function SimpleDeclaration1() {
     problem: `
 
           var ${varName};
-          name = "${name}";
+          ${varName} = "${name}";
 
       What value is stored in variable \`${varName}\`?
 


### PR DESCRIPTION
Just ran through the exercises and noticed an issue with the variable declaration question which assigns a value after the variable has been declared.

See the below screenshots for examples of the answer wrongly being marked as both correct & incorrect.

Great resource by the way, I'm looking forward to testing my ES6 knowledge next.

![screen shot 2015-05-29 at 13 03 26](https://cloud.githubusercontent.com/assets/894092/7882293/1cd633a2-0604-11e5-949d-f701618d106e.png)

![screen shot 2015-05-29 at 13 11 08](https://cloud.githubusercontent.com/assets/894092/7882313/41a74d24-0604-11e5-820c-6dc357b43edd.png)

